### PR TITLE
If a captcha token is already marked as solved in the database, the c…

### DIFF
--- a/pages/api/captcha/status/[token].js
+++ b/pages/api/captcha/status/[token].js
@@ -1,0 +1,27 @@
+import { supabase } from '../../../../lib/supabaseClient'
+
+export default async function handler(req, res) {
+	if (req.method !== 'GET') {
+		res.setHeader('Allow', 'GET')
+		return res.status(405).json({ error: 'Method Not Allowed' })
+	}
+	const token = req.query.token
+	if (!token || typeof token !== 'string') {
+		return res.status(400).json({ error: 'Missing token' })
+	}
+	try {
+		const { data, error } = await supabase
+			.from('captcha_tokens')
+			.select('id, solved')
+			.eq('token', token)
+			.single()
+
+		if (error || !data) {
+			return res.status(200).json({ valid: false, solved: false })
+		}
+
+		res.status(200).json({ valid: true, solved: data.solved })
+	} catch (e) {
+		res.status(200).json({ valid: false, solved: false })
+	}
+}


### PR DESCRIPTION
…aptcha page will now show a success message directly, instead of presenting the user with the captcha challenge again.

To achieve this, the following changes were made:
- A new API endpoint `/api/captcha/status/[token]` was created to check the `valid` and `solved` status of a token without causing any side effects.
- The `getServerSideProps` function in `pages/captcha/[token].jsx` was updated to call this new endpoint.
- The `CaptchaPage` component was updated to accept a `solved` prop and conditionally render either the success message or the captcha challenge.